### PR TITLE
Bug/keywords_next_page

### DIFF
--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -138,7 +138,7 @@ const Dashboard: NextPage = () => {
   const columns = [
     {
       id: "id",
-      align: "center",
+      align: "left",
       label: t("ID"),
       hide: false,
     },
@@ -345,7 +345,7 @@ const Dashboard: NextPage = () => {
                   component="div"
                   rowsPerPage={limit}
                   page={page}
-                  count={data?.count || 1}
+                  count={-1}
                   onPageChange={handleChangePage}
                   onRowsPerPageChange={handleChangeRowsPerPage}
                 />


### PR DESCRIPTION
Bug/keywords_next_page

bug at page/dashboard (keywords index)
- in case records > 15, user can click to next the page